### PR TITLE
Allow reading JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,25 +75,44 @@ Here `subjective_model` are the available subjective models offered in the packa
   - SR_DMOS - Apply SR, before calculating DMOS
   - ZS_SR_DMOS - Apply z-score transformation, followed by SR, before calculating DMOS
 
-`dataset_filepath` is the path to a dataset file. There are two ways to construct a dataset file. The first way is only useful when the subjective test is full sampling, i.e. every subject views every distorted video. For example:
+### Dataset Files
+
+`dataset_filepath` is the path to a dataset file. Dataset files may be `.py` or `.json` files. The following examples use `.py` files, but JSON-formatted files can be constructed in a similar fashion.
+
+There are two ways to construct a dataset file. The first way is only useful when the subjective test is full sampling, i.e. every subject views every distorted video. For example:
 
 ```
-from vmaf.config import VmafConfig
 ref_videos = [
-    {'content_id': 0, 'content_name': 'checkerboard', 'path': 
-        VmafConfig.test_resource_path('yuv', 'checkerboard_1920_1080_10_3_0_0.yuv')},
-    {'content_id': 1, 'content_name': 'flat', 'path': 
-        VmafConfig.test_resource_path('yuv', 'flat_1920_1080_0.yuv')},
+    {
+      'content_id': 0, 'content_name': 'checkerboard',
+      'path': 'checkerboard_1920_1080_10_3_0_0.yuv'
+    },
+    {
+      'content_id': 1, 'content_name': 'flat',
+      'path': 'flat_1920_1080_0.yuv'
+    },
 ]
 dis_videos = [
-    {'content_id': 0, 'asset_id': 0, 'os': [100, 100, 100, 100, 100], 'path': 
-        VmafConfig.test_resource_path('yuv', 'checkerboard_1920_1080_10_3_0_0.yuv')},
-    {'content_id': 0, 'asset_id': 1, 'os': [40, 45, 50, 55, 60],  'path': 
-        VmafConfig.test_resource_path('yuv', 'checkerboard_1920_1080_10_3_1_0.yuv')},
-    {'content_id': 1, 'asset_id': 2, 'os': [90, 90, 90, 90, 90],  'path': 
-        VmafConfig.test_resource_path('yuv', 'flat_1920_1080_0.yuv')},
-    {'content_id': 1, 'asset_id': 3, 'os': [70, 75, 80, 85, 90],  'path': 
-        VmafConfig.test_resource_path('yuv', 'flat_1920_1080_10.yuv')},
+    {
+      'content_id': 0, 'asset_id': 0,
+      'os': [100, 100, 100, 100, 100],
+      'path': 'checkerboard_1920_1080_10_3_0_0.yuv'
+    },
+    {
+      'content_id': 0, 'asset_id': 1,
+      'os': [40, 45, 50, 55, 60],
+      'path': 'checkerboard_1920_1080_10_3_1_0.yuv'
+    },
+    {
+      'content_id': 1, 'asset_id': 2,
+      'os': [90, 90, 90, 90, 90],
+      'path': 'flat_1920_1080_0.yuv'
+    },
+    {
+      'content_id': 1, 'asset_id': 3,
+      'os': [70, 75, 80, 85, 90],
+      'path': 'flat_1920_1080_10.yuv'
+    },
 ]
 ref_score = 100
 ```

--- a/python/script/run_subj.py
+++ b/python/script/run_subj.py
@@ -59,7 +59,7 @@ def main():
     )
 
     if print_:
-        print("Dataset: {}".format(dataset.__file__))
+        print("Dataset: {}".format(dataset_filepath))
         print("Subjective Model: {} {}".format(subjective_models[0].TYPE, subjective_models[0].VERSION))
         print("Result:")
         pprint.pprint(results[0])

--- a/python/src/sureal/routine.py
+++ b/python/src/sureal/routine.py
@@ -2,7 +2,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from sureal.dataset_reader import RawDatasetReader
-from sureal.tools.misc import import_python_file
+from sureal.tools.misc import import_python_file, import_json_file
 
 __copyright__ = "Copyright 2016-2018, Netflix, Inc."
 __license__ = "Apache, Version 2.0"
@@ -30,7 +30,12 @@ def run_subjective_models(dataset_filepath, subjective_model_classes, do_plot=No
 
     colors = ['black', 'gray', 'blue', 'red'] * 2
 
-    dataset = import_python_file(dataset_filepath)
+    if dataset_filepath.endswith('.py'):
+        dataset = import_python_file(dataset_filepath)
+    elif dataset_filepath.endswith('.json'):
+        dataset = import_json_file(dataset_filepath)
+    else:
+        raise AssertionError("Unknown input type, must be .py or .json")
     dataset_reader = dataset_reader_class(dataset, input_dict=dataset_reader_info_dict)
 
     subjective_models = map(

--- a/python/src/sureal/tools/misc.py
+++ b/python/src/sureal/tools/misc.py
@@ -70,6 +70,19 @@ def indices(a, func):
     """
     return [i for (i, val) in enumerate(a) if func(val)]
 
+def import_json_file(filepath):
+    """
+    Import a JSON-formatted input file as a dict.
+    :param filepath:
+    :return:
+    """
+    import json
+    from argparse import Namespace
+    with open(filepath, 'r') as in_f:
+        ret = json.load(in_f)
+    ns = Namespace(**ret)  # convert dict to namespace
+    return ns
+
 def import_python_file(filepath):
     """
     Import a python file as a module.


### PR DESCRIPTION
Allow input to be JSON files, such that it is easier to procedurally generate
the files (e.g. from another script that outputs JSON). JSON input will be
read as a dictionary and put into a namespace.

Improve the README by mentioning the two input formats, and clean up the
example given such that it is easier to read and does not rely on the VMAF
configuration (which is not necessary to run the model).

Signed-off-by: Werner Robitza <werner.robitza@gmail.com>